### PR TITLE
Bump contracts pkg to fix local env

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
             "dependencies": {
                 "@alch/alchemy-web3": "^1.4.7",
                 "@desci-labs/desci-codex-lib": "^1.1.7",
-                "@desci-labs/desci-contracts": "^0.2.6",
+                "@desci-labs/desci-contracts": "^0.2.7",
                 "@desci-labs/desci-models": "^0.2.5",
                 "@supabase/supabase-js": "^2.43.5",
                 "axios": "^1.7.2",
@@ -1386,9 +1386,9 @@
             }
         },
         "node_modules/@desci-labs/desci-contracts": {
-            "version": "0.2.6",
-            "resolved": "https://registry.npmjs.org/@desci-labs/desci-contracts/-/desci-contracts-0.2.6.tgz",
-            "integrity": "sha512-1PTKgGtHIrWZ/UMIrOs/tVrAdGUQC+QW+OLiBlEi2sV2UXsazZTjMbiGxjErP+VBPoMkFbfsWiLMvgjs6Pw/5A=="
+            "version": "0.2.7",
+            "resolved": "https://registry.npmjs.org/@desci-labs/desci-contracts/-/desci-contracts-0.2.7.tgz",
+            "integrity": "sha512-T5XhH0qn7z93jb9MlGd68i4mf0tJP+ppfyWKfFBjp+dCUC4GeTMM3Z/6eqaD8QXsBpvRfi+cvb0or3BY47MR2A=="
         },
         "node_modules/@desci-labs/desci-models": {
             "version": "0.2.5",
@@ -16859,9 +16859,9 @@
             }
         },
         "@desci-labs/desci-contracts": {
-            "version": "0.2.6",
-            "resolved": "https://registry.npmjs.org/@desci-labs/desci-contracts/-/desci-contracts-0.2.6.tgz",
-            "integrity": "sha512-1PTKgGtHIrWZ/UMIrOs/tVrAdGUQC+QW+OLiBlEi2sV2UXsazZTjMbiGxjErP+VBPoMkFbfsWiLMvgjs6Pw/5A=="
+            "version": "0.2.7",
+            "resolved": "https://registry.npmjs.org/@desci-labs/desci-contracts/-/desci-contracts-0.2.7.tgz",
+            "integrity": "sha512-T5XhH0qn7z93jb9MlGd68i4mf0tJP+ppfyWKfFBjp+dCUC4GeTMM3Z/6eqaD8QXsBpvRfi+cvb0or3BY47MR2A=="
         },
         "@desci-labs/desci-models": {
             "version": "0.2.5",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "dependencies": {
         "@alch/alchemy-web3": "^1.4.7",
         "@desci-labs/desci-codex-lib": "^1.1.7",
-        "@desci-labs/desci-contracts": "^0.2.6",
+        "@desci-labs/desci-contracts": "^0.2.7",
         "@desci-labs/desci-models": "^0.2.5",
         "@supabase/supabase-js": "^2.43.5",
         "axios": "^1.7.2",


### PR DESCRIPTION
Bumps desci-contracts to the latest version to use the deterministically created contract address from a fresh repo for local dev environments

Our dpid-resolver ECR image needs to be updated with this change as well.