### PR TITLE
Fix DAG exploration performance for MyST responses

### DIFF
--- a/src/api/v2/data/getIpfsFolder.ts
+++ b/src/api/v2/data/getIpfsFolder.ts
@@ -48,25 +48,8 @@ const getKeyForIpfsTree = (cid: string, rootName: string, depthKey: string) =>
 const getKeyForDagNode = (cid: string) => `resolver-v6-${DPID_ENV}-dag-node-${cid}`;
 const DAG_NODE_CACHE_TTL = 4 * 60 * 60; // 4 hours
 
-// Subtree cache: stores completed directory subtrees for progressive resolution
-const getKeyForSubtree = (cid: string) => `resolver-v6-${DPID_ENV}-ipfs-subtree-full-${cid}`;
-
 // Singleflight: coalesces concurrent requests for the same tree to prevent worker stacking
 const inflightTrees = new Map<string, Promise<IpfsEntry>>();
-
-/**
- * Fix paths in a cached subtree when grafting it at a new position in the tree.
- * CIDs are content-addressed so the tree structure is identical, but the absolute
- * paths depend on where in the parent tree the subtree is mounted.
- */
-const fixSubtreePaths = (entry: IpfsEntry, basePath: string) => {
-    entry.path = basePath;
-    if (entry.children) {
-        for (const child of entry.children) {
-            fixSubtreePaths(child, `${basePath}/${child.name}`);
-        }
-    }
-};
 
 export type IpfsEntry = {
     name: string;
@@ -306,9 +289,7 @@ const isUnixFsDirectory = (dagNode: any): boolean => dagNode?.Data?.["/"]?.bytes
  * Limits concurrent DAG fetches to avoid overloading the IPFS gateway.
  *
  * Uses singleflight to prevent thundering herd (concurrent requests for the same
- * tree share one resolution), DFS traversal order (subtrees complete before siblings),
- * and progressive subtree caching (completed subtrees are cached individually so that
- * retries after partial failures make forward progress).
+ * tree share one resolution). The full tree is cached on successful completion.
  */
 export const getIpfsFolderTreeByCid = async (
     rootCid: string,
@@ -344,11 +325,7 @@ export const getIpfsFolderTreeByCid = async (
 };
 
 /**
- * Internal: resolve an IPFS tree using DFS traversal with progressive subtree caching.
- *
- * DFS (depth-first) traversal means subtrees complete before sibling branches are explored.
- * This enables caching completed subtrees individually, so that even if the full tree
- * resolution times out, progress is preserved for the next attempt.
+ * Internal: resolve an IPFS tree using concurrent workers.
  */
 async function resolveIpfsTree(
     rootCid: string,
@@ -367,7 +344,7 @@ async function resolveIpfsTree(
             type: "file",
             gateway: rootDag.gateway,
         };
-        void redisService?.setToCache(cacheKey, fileEntry, CACHE_TTL_ANCHORED);
+        await redisService?.setToCache(cacheKey, fileEntry, CACHE_TTL_ANCHORED);
         return fileEntry;
     }
 
@@ -383,39 +360,6 @@ async function resolveIpfsTree(
         gateway?: string;
     };
     const queue: QueueItem[] = [];
-    const useSubtreeCache = maxDepth === "full";
-
-    // --- Subtree completion tracking ---
-    // Each directory tracks how many of its children are still pending resolution.
-    // When a directory's pending count reaches 0, its subtree is fully resolved and
-    // can be cached. Completion propagates upward to the parent.
-    const pendingChildren = new Map<IpfsEntry, number>();
-    const parentOf = new Map<IpfsEntry, IpfsEntry>();
-    const subtreeHasError = new Set<IpfsEntry>();
-    const cachedSubtreeKeys: string[] = [];
-
-    const onChildResolved = (parent: IpfsEntry, childHadError: boolean) => {
-        if (childHadError) subtreeHasError.add(parent);
-        const remaining = (pendingChildren.get(parent) ?? 1) - 1;
-        pendingChildren.set(parent, remaining);
-
-        if (remaining === 0) {
-            const hasError = subtreeHasError.has(parent);
-
-            // Cache this completed subtree (skip root; it gets the full-tree cache)
-            if (useSubtreeCache && redisService && !hasError && parent !== root) {
-                const subtreeKey = getKeyForSubtree(parent.cid);
-                cachedSubtreeKeys.push(subtreeKey);
-                void redisService?.setToCache(subtreeKey, parent, CACHE_TTL_ANCHORED);
-            }
-
-            // Propagate completion to grandparent
-            const grandparent = parentOf.get(parent);
-            if (grandparent) {
-                onChildResolved(grandparent, hasError);
-            }
-        }
-    };
 
     const enqueueChildren = (parent: IpfsEntry, dagNode: any, parentPath: string, parentDepth: number): number => {
         const links: Array<{ Name: string; Hash: unknown; Tsize?: number }> = dagNode?.Links ?? [];
@@ -457,14 +401,11 @@ async function resolveIpfsTree(
         return enqueued;
     };
 
-    const rootChildCount = enqueueChildren(root, rootDag, root.path, 0);
-    pendingChildren.set(root, rootChildCount);
+    enqueueChildren(root, rootDag, root.path, 0);
 
     const workers: Promise<void>[] = [];
     let hasErrors = false;
 
-    // DFS: pop from end of array (LIFO/stack) so workers explore depth-first.
-    // This completes subtrees before moving to sibling branches, enabling progressive caching.
     const take = (): QueueItem | undefined => (queue.length > 0 ? queue.pop() : undefined);
 
     const worker = async () => {
@@ -473,21 +414,6 @@ async function resolveIpfsTree(
         // eslint-disable-next-line no-cond-assign
         while ((item = take()) !== undefined) {
             try {
-                // Check subtree cache: if this CID's full subtree was resolved in a previous
-                // (possibly timed-out) request, graft it directly instead of re-traversing
-                if (useSubtreeCache) {
-                    const subtreeKey = getKeyForSubtree(item.cid);
-                    const cachedSubtree = await redisService?.getFromCache<IpfsEntry>(subtreeKey);
-                    if (cachedSubtree) {
-                        cachedSubtree.name = item.linkName;
-                        fixSubtreePaths(cachedSubtree, item.path);
-                        item.parent.children!.push(cachedSubtree);
-                        cachedSubtreeKeys.push(subtreeKey);
-                        onChildResolved(item.parent, false);
-                        continue;
-                    }
-                }
-
                 // Raw-codec CIDs are always leaf files; probe for a serving
                 // gateway via HEAD instead of downloading the full content.
                 if (isRawCodecCid(item.cid)) {
@@ -501,7 +427,6 @@ async function resolveIpfsTree(
                         gateway,
                     };
                     item.parent.children!.push(fileEntry);
-                    onChildResolved(item.parent, false);
                     continue;
                 }
 
@@ -516,15 +441,7 @@ async function resolveIpfsTree(
                         gateway: dagNode.gateway,
                     };
                     item.parent.children!.push(dirEntry);
-
-                    const childCount = enqueueChildren(dirEntry, dagNode, item.path, item.depth);
-                    if (childCount > 0) {
-                        pendingChildren.set(dirEntry, childCount);
-                        parentOf.set(dirEntry, item.parent);
-                    } else {
-                        // Empty or depth-limited directory: immediately complete
-                        onChildResolved(item.parent, false);
-                    }
+                    enqueueChildren(dirEntry, dagNode, item.path, item.depth);
                 } else {
                     const fileEntry: EnhancedIpfsEntry = {
                         name: item.linkName,
@@ -535,11 +452,9 @@ async function resolveIpfsTree(
                         gateway: dagNode.gateway,
                     };
                     item.parent.children!.push(fileEntry);
-                    onChildResolved(item.parent, false);
                 }
             } catch (error) {
                 hasErrors = true;
-                onChildResolved(item.parent, true);
                 const errorTyped = error as {
                     message?: string;
                     response?: { data?: { Message?: string }; status?: number };
@@ -568,19 +483,12 @@ async function resolveIpfsTree(
     }
     await Promise.all(workers);
 
-    // Cache full tree if no errors, and clean up now-redundant subtree cache entries
+    // Cache full tree if no errors occurred during resolution.
+    // Await the write so singleflight isn't cleared before cache is set.
     if (!hasErrors) {
-        void redisService?.setToCache(cacheKey, root, CACHE_TTL_ANCHORED).then((wasSet) => {
-            if (wasSet) {
-                // Full tree cached — subtree entries are now redundant, clean them up
-                void redisService?.del(...cachedSubtreeKeys);
-            }
-        });
+        await redisService?.setToCache(cacheKey, root, CACHE_TTL_ANCHORED);
     } else {
-        logger.info(
-            { cacheKey, rootCid },
-            "Skipping full tree cache due to errors (subtrees may be cached individually)",
-        );
+        logger.info({ cacheKey, rootCid }, "Skipping full tree cache due to errors");
     }
 
     return root;

--- a/src/api/v2/data/getIpfsFolder.ts
+++ b/src/api/v2/data/getIpfsFolder.ts
@@ -95,7 +95,20 @@ const fetchViaPublicHttpGateway = async (cid: string): Promise<unknown> => {
     return null;
 };
 
-export const ipfsCat = async (arg: string): Promise<unknown> => {
+/** Get JSON data from IPFS. When used for small files, shouldCache can be used to serve it
+ * from redis
+ */
+export const ipfsCat = async (arg: string, shouldCache: boolean = false): Promise<unknown> => {
+    const cacheKey = `resolver-${DPID_ENV}-cat-${arg}`;
+    if (shouldCache) {
+        const cachedContent = await redisService?.getFromCache(cacheKey);
+        if (cachedContent) {
+            logger.info({ cacheKey }, "Serving ipfsCat from cache");
+            void redisService?.keyBump(cacheKey, CACHE_TTL_ANCHORED);
+            return cachedContent;
+        }
+    }
+
     const url = `${IPFS_GATEWAY.replace(/\/ipfs$/, "")}/api/v0/cat?arg=${encodeURIComponent(arg)}`;
     logger.info({ url }, "Fetching IPFS content via public HTTP gateway");
     const { data } = await axios({
@@ -109,7 +122,11 @@ export const ipfsCat = async (arg: string): Promise<unknown> => {
 
     // Attempt to parse as JSON, throw descriptive error if it fails
     try {
-        return JSON.parse(data);
+        const parsed = JSON.parse(data);
+        if (shouldCache) {
+            void redisService?.setToCache(cacheKey, parsed, CACHE_TTL_ANCHORED);
+        }
+        return parsed;
     } catch (e) {
         const preview = typeof data === "string" ? data.slice(0, 100) : String(data);
         throw new Error(`ipfsCat: expected JSON response but got: "${preview}..."`);

--- a/src/api/v2/data/getIpfsFolder.ts
+++ b/src/api/v2/data/getIpfsFolder.ts
@@ -25,6 +25,16 @@ const PUBLIC_IPFS_GATEWAYS = process.env.PUBLIC_IPFS_GATEWAYS
       ];
 const MAGIC_UNIXFS_DIR_FLAG = "CAE"; // length-delimited protobuf [0x08, 0x01] => Directory
 
+/**
+ * Check if a CID uses the raw codec (multicodec 0x55), meaning it's a leaf
+ * file whose content IS the raw bytes — never a UnixFS directory.
+ *
+ * CIDv1 base32 encodes: <multibase><version><codec><multihash...>
+ * "bafkrei" = base32lower 'b' + CIDv1 version 0x01 + raw codec 0x55 + sha2-256 0x1220.
+ * Any CID starting with this prefix is guaranteed to be a raw file leaf.
+ */
+const isRawCodecCid = (cid: string): boolean => cid.startsWith("bafkrei");
+
 // Cache key version history:
 // v2: Initial versioned cache key
 // v3: Invalidated to force re-fetch with public gateway fallback for missing files
@@ -68,17 +78,34 @@ export type IpfsEntry = {
 };
 
 /**
- * Check content existence on public HTTP gateway without downloading the body (HEAD).
- * Returns a minimal DAG-like object to indicate a file node when found.
- * This is a fallback when DAG API is unavailable.
+ * Probe gateways with HEAD requests to find one that can serve a CID, without
+ * downloading the body. Checks DAG API gateways first (via their /ipfs path),
+ * then public HTTP gateways. Returns the gateway base URL on success, using
+ * the DAG API URL for DAG API gateways so downstream consumers get the format
+ * they expect.
  */
-const fetchViaPublicHttpGateway = async (cid: string): Promise<unknown> => {
-    for (const gateway of PUBLIC_IPFS_GATEWAYS) {
+const probeGatewayForCid = async (cid: string): Promise<string | undefined> => {
+    // Build probe list: DAG API gateways first (probed via /ipfs, returned as /api/v0),
+    // then public HTTP gateways (probed and returned as-is)
+    const probes: Array<{ probeUrl: string; returnUrl: string }> = [];
+    for (const dagApiUrl of [IPFS_DAG_API_URL, ...IPFS_DAG_API_FALLBACK_URLS]) {
+        probes.push({
+            probeUrl: `${dagApiUrl.replace(/\/api\/v0$/, "/ipfs")}/${cid}`,
+            returnUrl: dagApiUrl,
+        });
+    }
+    for (const publicGw of PUBLIC_IPFS_GATEWAYS) {
+        probes.push({
+            probeUrl: `${publicGw}/${cid}`,
+            returnUrl: publicGw,
+        });
+    }
+
+    for (const { probeUrl, returnUrl } of probes) {
         try {
-            const url = `${gateway}/${cid}`;
             const response = await axios({
                 method: "HEAD",
-                url,
+                url: probeUrl,
                 timeout: 15000,
                 validateStatus: (status) => status === 200 || status === 404,
                 httpAgent,
@@ -86,37 +113,19 @@ const fetchViaPublicHttpGateway = async (cid: string): Promise<unknown> => {
             });
 
             if (response.status === 200) {
-                logger.info(
-                    {
-                        cid,
-                        gateway,
-                        contentType: response.headers["content-type"],
-                        contentLength: response.headers["content-length"],
-                    },
-                    "Content exists on public HTTP gateway (HEAD)",
-                );
-
-                // Return a minimal structure that will be treated as a file (not a directory)
-                // by isUnixFsDirectory (bytes !== MAGIC_UNIXFS_DIR_FLAG)
-                return {
-                    Data: {
-                        "/": {
-                            bytes: "",
-                        },
-                    },
-                    Links: [],
-                };
+                logger.info({ cid, probeUrl, gateway: returnUrl }, "Content found via HEAD probe");
+                return returnUrl;
             }
         } catch (error) {
             const axiosError = error as { response?: { status?: number }; message?: string };
             if (axiosError.response?.status === 404) {
-                logger.debug({ cid, gateway }, "CID not found on this public gateway");
+                logger.debug({ cid, probeUrl }, "CID not found on gateway");
                 continue;
             }
-            logger.debug({ cid, gateway, error: axiosError.message }, "Failed to query public gateway (HEAD)");
+            logger.debug({ cid, probeUrl, error: axiosError.message }, "HEAD probe failed");
         }
     }
-    return null;
+    return undefined;
 };
 
 /** Get JSON data from IPFS. When used for small files, shouldCache can be used to serve it
@@ -262,18 +271,25 @@ export const fetchDagNode = async (arg: string, retries = 2): Promise<EnhancedIp
     const lastErrorTyped = lastError as { response?: { data?: { Message?: string } }; message?: string } | undefined;
     const errorMsg = lastErrorTyped?.response?.data?.Message || lastErrorTyped?.message || "Unknown error";
 
-    logger.debug({ cid: arg }, "All DAG API gateways failed, trying public HTTP gateways");
-    const publicData = await fetchViaPublicHttpGateway(arg);
+    logger.debug({ cid: arg }, "All DAG API gateways failed, probing for content via HEAD");
+    const probeGateway = await probeGatewayForCid(arg);
 
-    if (publicData) {
+    if (probeGateway) {
         logger.info(
             {
                 cid: arg,
-                note: "Content fetched from public IPFS gateway - consider pinning to ipfs.desci.com",
+                gateway: probeGateway,
+                note: "Content found via HEAD probe - consider pinning to ipfs.desci.com",
             },
-            "Using public gateway fallback for missing CID",
+            "Using probed gateway fallback for missing CID",
         );
-        const result = { ...publicData, gateway: "public" } as EnhancedIpfsEntry;
+        const result: EnhancedIpfsEntry = {
+            name: "",
+            path: "",
+            cid: arg,
+            type: "file",
+            gateway: probeGateway,
+        };
         void redisService?.setToCache(cacheKey, result, DAG_NODE_CACHE_TTL);
         return result;
     }
@@ -357,7 +373,15 @@ async function resolveIpfsTree(
 
     const root: IpfsEntry = { name: rootName, path: rootName, cid: rootCid, type: "directory", children: [] };
 
-    type QueueItem = { parent: IpfsEntry; linkName: string; cid: string; path: string; size?: number; depth: number };
+    type QueueItem = {
+        parent: IpfsEntry;
+        linkName: string;
+        cid: string;
+        path: string;
+        size?: number;
+        depth: number;
+        gateway?: string;
+    };
     const queue: QueueItem[] = [];
     const useSubtreeCache = maxDepth === "full";
 
@@ -395,6 +419,9 @@ async function resolveIpfsTree(
 
     const enqueueChildren = (parent: IpfsEntry, dagNode: any, parentPath: string, parentDepth: number): number => {
         const links: Array<{ Name: string; Hash: unknown; Tsize?: number }> = dagNode?.Links ?? [];
+        // The gateway that served this directory's DAG node — its children are
+        // very likely available on the same gateway since IPFS pins entire DAGs.
+        const dagGateway: string | undefined = dagNode?.gateway;
         let enqueued = 0;
 
         for (const link of links) {
@@ -422,6 +449,7 @@ async function resolveIpfsTree(
                 path: childPath,
                 size: link.Tsize,
                 depth: childDepth,
+                gateway: dagGateway,
             });
             enqueued++;
         }
@@ -460,6 +488,23 @@ async function resolveIpfsTree(
                     }
                 }
 
+                // Raw-codec CIDs are always leaf files; probe for a serving
+                // gateway via HEAD instead of downloading the full content.
+                if (isRawCodecCid(item.cid)) {
+                    const gateway = await probeGatewayForCid(item.cid);
+                    const fileEntry: EnhancedIpfsEntry = {
+                        name: item.linkName,
+                        path: item.path,
+                        cid: item.cid,
+                        size: item.size,
+                        type: "file",
+                        gateway,
+                    };
+                    item.parent.children!.push(fileEntry);
+                    onChildResolved(item.parent, false);
+                    continue;
+                }
+
                 const dagNode: any = await fetchDagNode(item.cid);
                 if (isUnixFsDirectory(dagNode)) {
                     const dirEntry: EnhancedIpfsEntry = {
@@ -468,7 +513,7 @@ async function resolveIpfsTree(
                         cid: item.cid,
                         type: "directory",
                         children: [],
-                        gateway: (item.parent as EnhancedIpfsEntry).gateway,
+                        gateway: dagNode.gateway,
                     };
                     item.parent.children!.push(dirEntry);
 

--- a/src/api/v2/data/getIpfsFolder.ts
+++ b/src/api/v2/data/getIpfsFolder.ts
@@ -34,6 +34,30 @@ const MAGIC_UNIXFS_DIR_FLAG = "CAE"; // length-delimited protobuf [0x08, 0x01] =
 const getKeyForIpfsTree = (cid: string, rootName: string, depthKey: string) =>
     `resolver-v6-${DPID_ENV}-ipfs-tree-${rootName}-${depthKey}-${cid}`;
 
+// Per-CID DAG node cache: avoids redundant IPFS HTTP calls on retries
+const getKeyForDagNode = (cid: string) => `resolver-v6-${DPID_ENV}-dag-node-${cid}`;
+const DAG_NODE_CACHE_TTL = 4 * 60 * 60; // 4 hours
+
+// Subtree cache: stores completed directory subtrees for progressive resolution
+const getKeyForSubtree = (cid: string) => `resolver-v6-${DPID_ENV}-ipfs-subtree-full-${cid}`;
+
+// Singleflight: coalesces concurrent requests for the same tree to prevent worker stacking
+const inflightTrees = new Map<string, Promise<IpfsEntry>>();
+
+/**
+ * Fix paths in a cached subtree when grafting it at a new position in the tree.
+ * CIDs are content-addressed so the tree structure is identical, but the absolute
+ * paths depend on where in the parent tree the subtree is mounted.
+ */
+const fixSubtreePaths = (entry: IpfsEntry, basePath: string) => {
+    entry.path = basePath;
+    if (entry.children) {
+        for (const child of entry.children) {
+            fixSubtreePaths(child, `${basePath}/${child.name}`);
+        }
+    }
+};
+
 export type IpfsEntry = {
     name: string;
     path: string;
@@ -137,6 +161,15 @@ export type EnhancedIpfsEntry = IpfsEntry & { gateway?: string; cid: string; nam
 
 /** Fetch a DAG node via IPFS HTTP API with retry logic and fallback gateway support */
 export const fetchDagNode = async (arg: string, retries = 2): Promise<EnhancedIpfsEntry> => {
+    // Check per-CID cache to avoid redundant IPFS fetches on retries
+    const cacheKey = getKeyForDagNode(arg);
+    const cached = await redisService?.getFromCache<EnhancedIpfsEntry>(cacheKey);
+    if (cached) {
+        logger.info({ cacheKey }, "Serving dag node from cache");
+        void redisService?.keyBump(cacheKey, DAG_NODE_CACHE_TTL);
+        return cached;
+    }
+
     const gateways = [IPFS_DAG_API_URL, ...IPFS_DAG_API_FALLBACK_URLS];
     let lastError: unknown;
 
@@ -163,7 +196,9 @@ export const fetchDagNode = async (arg: string, retries = 2): Promise<EnhancedIp
                         "Successfully fetched DAG node from fallback gateway",
                     );
                 }
-                return { ...data, gateway: chosenGateway } as EnhancedIpfsEntry;
+                const result = { ...data, gateway: chosenGateway } as EnhancedIpfsEntry;
+                void redisService?.setToCache(cacheKey, result, DAG_NODE_CACHE_TTL);
+                return result;
             } catch (error) {
                 const axiosError = error as {
                     response?: { status?: number; data?: { Message?: string } };
@@ -238,7 +273,9 @@ export const fetchDagNode = async (arg: string, retries = 2): Promise<EnhancedIp
             },
             "Using public gateway fallback for missing CID",
         );
-        return { ...publicData, gateway: "public" } as EnhancedIpfsEntry;
+        const result = { ...publicData, gateway: "public" } as EnhancedIpfsEntry;
+        void redisService?.setToCache(cacheKey, result, DAG_NODE_CACHE_TTL);
+        return result;
     }
 
     // Content not found anywhere
@@ -251,6 +288,11 @@ const isUnixFsDirectory = (dagNode: any): boolean => dagNode?.Data?.["/"]?.bytes
 /**
  * Recursively build a folder tree starting from a UnixFS root CID.
  * Limits concurrent DAG fetches to avoid overloading the IPFS gateway.
+ *
+ * Uses singleflight to prevent thundering herd (concurrent requests for the same
+ * tree share one resolution), DFS traversal order (subtrees complete before siblings),
+ * and progressive subtree caching (completed subtrees are cached individually so that
+ * retries after partial failures make forward progress).
  */
 export const getIpfsFolderTreeByCid = async (
     rootCid: string,
@@ -262,20 +304,43 @@ export const getIpfsFolderTreeByCid = async (
 
     const depthKey = maxDepth === "full" ? "full" : `d${maxDepth}`;
     const cacheKey = getKeyForIpfsTree(rootCid, rootName, depthKey);
-    if (redisService) {
-        try {
-            const cached = await redisService.getFromCache<IpfsEntry>(cacheKey);
-            if (cached !== null) {
-                void redisService.keyBump(cacheKey, CACHE_TTL_ANCHORED).catch((error) => {
-                    logger.warn({ error, key: cacheKey }, "Failed to bump Redis key TTL for ipfs tree");
-                });
-                return cached;
-            }
-        } catch (error) {
-            logger.warn({ error, key: cacheKey }, "Failed to read from Redis cache for ipfs tree");
-        }
+
+    // 1. Check full-tree cache
+    const cached = await redisService?.getFromCache<IpfsEntry>(cacheKey);
+    if (cached) {
+        void redisService?.keyBump(cacheKey, CACHE_TTL_ANCHORED);
+        return cached;
     }
 
+    // 2. Singleflight: if another request is already resolving this exact tree, join it
+    //    instead of spawning a new set of workers (prevents worker stacking on retries)
+    const inflight = inflightTrees.get(cacheKey);
+    if (inflight) {
+        logger.info({ cacheKey, rootCid }, "Joining in-flight tree resolution");
+        return inflight;
+    }
+
+    // 3. Start new resolution and register in singleflight map
+    const promise = resolveIpfsTree(rootCid, rootName, maxConcurrency, maxDepth, cacheKey);
+    inflightTrees.set(cacheKey, promise);
+    promise.finally(() => inflightTrees.delete(cacheKey)).catch(() => {});
+    return promise;
+};
+
+/**
+ * Internal: resolve an IPFS tree using DFS traversal with progressive subtree caching.
+ *
+ * DFS (depth-first) traversal means subtrees complete before sibling branches are explored.
+ * This enables caching completed subtrees individually, so that even if the full tree
+ * resolution times out, progress is preserved for the next attempt.
+ */
+async function resolveIpfsTree(
+    rootCid: string,
+    rootName: string,
+    maxConcurrency: number,
+    maxDepth: number | "full",
+    cacheKey: string,
+): Promise<IpfsEntry> {
     const rootDag: any = await fetchDagNode(rootCid);
     const rootIsDir = isUnixFsDirectory(rootDag);
     if (!rootIsDir) {
@@ -286,11 +351,7 @@ export const getIpfsFolderTreeByCid = async (
             type: "file",
             gateway: rootDag.gateway,
         };
-        if (redisService) {
-            void redisService.setToCache(cacheKey, fileEntry, CACHE_TTL_ANCHORED).catch((error) => {
-                logger.warn({ error, key: cacheKey }, "Failed to set Redis cache for ipfs file entry");
-            });
-        }
+        void redisService?.setToCache(cacheKey, fileEntry, CACHE_TTL_ANCHORED);
         return fileEntry;
     }
 
@@ -298,9 +359,43 @@ export const getIpfsFolderTreeByCid = async (
 
     type QueueItem = { parent: IpfsEntry; linkName: string; cid: string; path: string; size?: number; depth: number };
     const queue: QueueItem[] = [];
+    const useSubtreeCache = maxDepth === "full";
 
-    const enqueueChildren = (parent: IpfsEntry, dagNode: any, parentPath: string, parentDepth: number) => {
+    // --- Subtree completion tracking ---
+    // Each directory tracks how many of its children are still pending resolution.
+    // When a directory's pending count reaches 0, its subtree is fully resolved and
+    // can be cached. Completion propagates upward to the parent.
+    const pendingChildren = new Map<IpfsEntry, number>();
+    const parentOf = new Map<IpfsEntry, IpfsEntry>();
+    const subtreeHasError = new Set<IpfsEntry>();
+    const cachedSubtreeKeys: string[] = [];
+
+    const onChildResolved = (parent: IpfsEntry, childHadError: boolean) => {
+        if (childHadError) subtreeHasError.add(parent);
+        const remaining = (pendingChildren.get(parent) ?? 1) - 1;
+        pendingChildren.set(parent, remaining);
+
+        if (remaining === 0) {
+            const hasError = subtreeHasError.has(parent);
+
+            // Cache this completed subtree (skip root; it gets the full-tree cache)
+            if (useSubtreeCache && redisService && !hasError && parent !== root) {
+                const subtreeKey = getKeyForSubtree(parent.cid);
+                cachedSubtreeKeys.push(subtreeKey);
+                void redisService?.setToCache(subtreeKey, parent, CACHE_TTL_ANCHORED);
+            }
+
+            // Propagate completion to grandparent
+            const grandparent = parentOf.get(parent);
+            if (grandparent) {
+                onChildResolved(grandparent, hasError);
+            }
+        }
+    };
+
+    const enqueueChildren = (parent: IpfsEntry, dagNode: any, parentPath: string, parentDepth: number): number => {
         const links: Array<{ Name: string; Hash: unknown; Tsize?: number }> = dagNode?.Links ?? [];
+        let enqueued = 0;
 
         for (const link of links) {
             let childCid: string | undefined;
@@ -328,23 +423,43 @@ export const getIpfsFolderTreeByCid = async (
                 size: link.Tsize,
                 depth: childDepth,
             });
+            enqueued++;
         }
+
+        return enqueued;
     };
 
-    enqueueChildren(root, rootDag, root.path, 0);
+    const rootChildCount = enqueueChildren(root, rootDag, root.path, 0);
+    pendingChildren.set(root, rootChildCount);
 
-    let index = 0;
     const workers: Promise<void>[] = [];
     let hasErrors = false;
 
-    const take = (): QueueItem | undefined => (index < queue.length ? queue[index++] : undefined);
+    // DFS: pop from end of array (LIFO/stack) so workers explore depth-first.
+    // This completes subtrees before moving to sibling branches, enabling progressive caching.
+    const take = (): QueueItem | undefined => (queue.length > 0 ? queue.pop() : undefined);
 
     const worker = async () => {
         let item: QueueItem | undefined;
-        // Drain queue; new children may extend queue while iterating
+        // Drain stack; new children may extend it while iterating
         // eslint-disable-next-line no-cond-assign
         while ((item = take()) !== undefined) {
             try {
+                // Check subtree cache: if this CID's full subtree was resolved in a previous
+                // (possibly timed-out) request, graft it directly instead of re-traversing
+                if (useSubtreeCache) {
+                    const subtreeKey = getKeyForSubtree(item.cid);
+                    const cachedSubtree = await redisService?.getFromCache<IpfsEntry>(subtreeKey);
+                    if (cachedSubtree) {
+                        cachedSubtree.name = item.linkName;
+                        fixSubtreePaths(cachedSubtree, item.path);
+                        item.parent.children!.push(cachedSubtree);
+                        cachedSubtreeKeys.push(subtreeKey);
+                        onChildResolved(item.parent, false);
+                        continue;
+                    }
+                }
+
                 const dagNode: any = await fetchDagNode(item.cid);
                 if (isUnixFsDirectory(dagNode)) {
                     const dirEntry: EnhancedIpfsEntry = {
@@ -356,8 +471,14 @@ export const getIpfsFolderTreeByCid = async (
                         gateway: (item.parent as EnhancedIpfsEntry).gateway,
                     };
                     item.parent.children!.push(dirEntry);
-                    if (maxDepth === "full" || item.depth < maxDepth) {
-                        enqueueChildren(dirEntry, dagNode, item.path, item.depth);
+
+                    const childCount = enqueueChildren(dirEntry, dagNode, item.path, item.depth);
+                    if (childCount > 0) {
+                        pendingChildren.set(dirEntry, childCount);
+                        parentOf.set(dirEntry, item.parent);
+                    } else {
+                        // Empty or depth-limited directory: immediately complete
+                        onChildResolved(item.parent, false);
                     }
                 } else {
                     const fileEntry: EnhancedIpfsEntry = {
@@ -369,9 +490,11 @@ export const getIpfsFolderTreeByCid = async (
                         gateway: dagNode.gateway,
                     };
                     item.parent.children!.push(fileEntry);
+                    onChildResolved(item.parent, false);
                 }
             } catch (error) {
                 hasErrors = true;
+                onChildResolved(item.parent, true);
                 const errorTyped = error as {
                     message?: string;
                     response?: { data?: { Message?: string }; status?: number };
@@ -382,8 +505,8 @@ export const getIpfsFolderTreeByCid = async (
                 logger.warn(
                     {
                         error: errorMessage,
-                        cid: item?.cid,
-                        path: item?.path,
+                        cid: item.cid,
+                        path: item.path,
                         isMissingContent,
                         status: errorTyped?.response?.status,
                     },
@@ -400,17 +523,23 @@ export const getIpfsFolderTreeByCid = async (
     }
     await Promise.all(workers);
 
-    // Only cache if we successfully fetched all children
-    if (redisService && !hasErrors) {
-        void redisService.setToCache(cacheKey, root, CACHE_TTL_ANCHORED).catch((error) => {
-            logger.warn({ error, key: cacheKey }, "Failed to set Redis cache for ipfs tree");
+    // Cache full tree if no errors, and clean up now-redundant subtree cache entries
+    if (!hasErrors) {
+        void redisService?.setToCache(cacheKey, root, CACHE_TTL_ANCHORED).then((wasSet) => {
+            if (wasSet) {
+                // Full tree cached — subtree entries are now redundant, clean them up
+                void redisService?.del(...cachedSubtreeKeys);
+            }
         });
-    } else if (hasErrors) {
-        logger.info({ cacheKey, rootCid }, "Skipping cache due to errors fetching some children");
+    } else {
+        logger.info(
+            { cacheKey, rootCid },
+            "Skipping full tree cache due to errors (subtrees may be cached individually)",
+        );
     }
 
     return root;
-};
+}
 
 /**
  * Resolve a DPID to its manifest, extract the `root` component's CID, and return the full IPFS tree.

--- a/src/api/v2/data/getIpfsFolder.ts
+++ b/src/api/v2/data/getIpfsFolder.ts
@@ -6,6 +6,7 @@ import { resolveDpid } from "../resolvers/dpid.js";
 import { redisService } from "../../../redis.js";
 import { getManifest } from "../../../util/manifests.js";
 import { httpAgent, httpsAgent } from "../../../util/httpAgent.js";
+import { hackyTsizeIsDir, isRawCodecCid, magicIsUnixFsDir, type PbLink } from "../../../util/ipfs.js";
 
 const logger = parentLogger.child({ module: "/api/v2/data/getIpfsFolder" });
 
@@ -23,17 +24,6 @@ const PUBLIC_IPFS_GATEWAYS = process.env.PUBLIC_IPFS_GATEWAYS
           "https://dweb.link/ipfs",
           "https://cloudflare-ipfs.com/ipfs",
       ];
-const MAGIC_UNIXFS_DIR_FLAG = "CAE"; // length-delimited protobuf [0x08, 0x01] => Directory
-
-/**
- * Check if a CID uses the raw codec (multicodec 0x55), meaning it's a leaf
- * file whose content IS the raw bytes — never a UnixFS directory.
- *
- * CIDv1 base32 encodes: <multibase><version><codec><multihash...>
- * "bafkrei" = base32lower 'b' + CIDv1 version 0x01 + raw codec 0x55 + sha2-256 0x1220.
- * Any CID starting with this prefix is guaranteed to be a raw file leaf.
- */
-const isRawCodecCid = (cid: string): boolean => cid.startsWith("bafkrei");
 
 // Cache key version history:
 // v2: Initial versioned cache key
@@ -149,13 +139,16 @@ export const ipfsCat = async (arg: string, shouldCache: boolean = false): Promis
     }
 };
 
-export type EnhancedIpfsEntry = IpfsEntry & { gateway?: string; cid: string; name: string };
+export type IpfsEntryWithGateway = IpfsEntry & {
+    gateway?: string;
+    children?: IpfsEntryWithGateway[] | undefined;
+};
 
 /** Fetch a DAG node via IPFS HTTP API with retry logic and fallback gateway support */
-export const fetchDagNode = async (arg: string, retries = 2): Promise<EnhancedIpfsEntry> => {
+export const fetchDagNode = async (arg: string, retries = 2): Promise<IpfsEntryWithGateway> => {
     // Check per-CID cache to avoid redundant IPFS fetches on retries
     const cacheKey = getKeyForDagNode(arg);
-    const cached = await redisService?.getFromCache<EnhancedIpfsEntry>(cacheKey);
+    const cached = await redisService?.getFromCache<IpfsEntryWithGateway>(cacheKey);
     if (cached) {
         logger.info({ cacheKey }, "Serving dag node from cache");
         void redisService?.keyBump(cacheKey, DAG_NODE_CACHE_TTL);
@@ -188,7 +181,7 @@ export const fetchDagNode = async (arg: string, retries = 2): Promise<EnhancedIp
                         "Successfully fetched DAG node from fallback gateway",
                     );
                 }
-                const result = { ...data, gateway: chosenGateway } as EnhancedIpfsEntry;
+                const result = { ...data, gateway: chosenGateway } as IpfsEntryWithGateway;
                 void redisService?.setToCache(cacheKey, result, DAG_NODE_CACHE_TTL);
                 return result;
             } catch (error) {
@@ -266,7 +259,7 @@ export const fetchDagNode = async (arg: string, retries = 2): Promise<EnhancedIp
             },
             "Using probed gateway fallback for missing CID",
         );
-        const result: EnhancedIpfsEntry = {
+        const result: IpfsEntryWithGateway = {
             name: "",
             path: "",
             cid: arg,
@@ -280,9 +273,6 @@ export const fetchDagNode = async (arg: string, retries = 2): Promise<EnhancedIp
     // Content not found anywhere
     throw new Error(`Failed to fetch DAG node ${arg} from all available gateways: ${errorMsg}`);
 };
-
-/* eslint-disable @typescript-eslint/no-explicit-any */
-const isUnixFsDirectory = (dagNode: any): boolean => dagNode?.Data?.["/"]?.bytes === MAGIC_UNIXFS_DIR_FLAG;
 
 /**
  * Recursively build a folder tree starting from a UnixFS root CID.
@@ -318,7 +308,7 @@ export const getIpfsFolderTreeByCid = async (
     }
 
     // 3. Start new resolution and register in singleflight map
-    const promise = resolveIpfsTree(rootCid, rootName, maxConcurrency, maxDepth, cacheKey);
+    const promise = resolveIpfsTree(rootCid, rootName, maxConcurrency, maxDepth, cacheKey, true);
     inflightTrees.set(cacheKey, promise);
     promise.finally(() => inflightTrees.delete(cacheKey)).catch(() => {});
     return promise;
@@ -333,11 +323,13 @@ async function resolveIpfsTree(
     maxConcurrency: number,
     maxDepth: number | "full",
     cacheKey: string,
+    /** hack for detecting dirs by looking for 0 Tsize, which is incorrect in the dag-pb */
+    abuseTsize: boolean = false,
 ): Promise<IpfsEntry> {
     const rootDag: any = await fetchDagNode(rootCid);
-    const rootIsDir = isUnixFsDirectory(rootDag);
+    const rootIsDir = magicIsUnixFsDir(rootDag);
     if (!rootIsDir) {
-        const fileEntry: EnhancedIpfsEntry = {
+        const fileEntry: IpfsEntryWithGateway = {
             name: rootName,
             path: rootName,
             cid: rootCid,
@@ -361,20 +353,12 @@ async function resolveIpfsTree(
     };
     const queue: QueueItem[] = [];
 
-    const enqueueChildren = (parent: IpfsEntry, dagNode: any, parentPath: string, parentDepth: number): number => {
-        const links: Array<{ Name: string; Hash: unknown; Tsize?: number }> = dagNode?.Links ?? [];
-        // The gateway that served this directory's DAG node — its children are
-        // very likely available on the same gateway since IPFS pins entire DAGs.
+    const enqueueChildren = (parent: IpfsEntryWithGateway, dagNode: any, parentPath: string, parentDepth: number) => {
+        const links: Array<PbLink> = dagNode?.Links ?? [];
         const dagGateway: string | undefined = dagNode?.gateway;
-        let enqueued = 0;
 
         for (const link of links) {
-            let childCid: string | undefined;
-            if (typeof link.Hash === "string") {
-                childCid = link.Hash;
-            } else if (link.Hash && typeof (link.Hash as any)["/"] === "string") {
-                childCid = (link.Hash as any)["/"] as string;
-            }
+            const childCid = link.Hash["/"];
 
             if (!childCid) {
                 logger.warn({ link }, "Skipping link without valid CID string");
@@ -386,19 +370,31 @@ async function resolveIpfsTree(
             if (maxDepth !== "full" && childDepth > maxDepth) {
                 continue;
             }
-            queue.push({
-                parent,
-                linkName: link.Name,
-                cid: childCid,
-                path: childPath,
-                size: link.Tsize,
-                depth: childDepth,
-                gateway: dagGateway,
-            });
-            enqueued++;
-        }
 
-        return enqueued;
+            // Link Tsize seems to often be 0 on dirs but never on files, this skips resolving files at all
+            if (abuseTsize && parentDepth !== 0 && !hackyTsizeIsDir(link)) {
+                parent.children!.push({
+                    name: link.Name,
+                    path: childPath,
+                    cid: link.Hash["/"],
+                    size: link.Tsize,
+                    type: "file",
+                    // WARN: this is only necessarily true for IJ pubs (only ext cids at non-root depths).
+                    // It is not generic, so if you're debugging non-IJ nodes returning wrong URLs - this is it
+                    gateway: "https://pub.desci.com/api/v0",
+                });
+            } else {
+                queue.push({
+                    parent,
+                    linkName: link.Name,
+                    cid: childCid,
+                    path: childPath,
+                    size: link.Tsize,
+                    depth: childDepth,
+                    gateway: dagGateway,
+                });
+            }
+        }
     };
 
     enqueueChildren(root, rootDag, root.path, 0);
@@ -416,23 +412,27 @@ async function resolveIpfsTree(
             try {
                 // Raw-codec CIDs are always leaf files; probe for a serving
                 // gateway via HEAD instead of downloading the full content.
-                if (isRawCodecCid(item.cid)) {
-                    const gateway = await probeGatewayForCid(item.cid);
-                    const fileEntry: EnhancedIpfsEntry = {
-                        name: item.linkName,
-                        path: item.path,
-                        cid: item.cid,
-                        size: item.size,
-                        type: "file",
-                        gateway,
-                    };
-                    item.parent.children!.push(fileEntry);
-                    continue;
-                }
+                //
+                // WARN: files over the chunk size are also split into a DAG, so this doesn't necessarily mean it's an entire file.
+                //
+                // INFO: this is uncessesary when enqueueChildren uses hackyTsizeIsDir to identify leaves, as leaves never hit the queue at all
+                // if (isRawCodecCid(item.cid)) {
+                //     const gateway = await probeGatewayForCid(item.cid);
+                //     const fileEntry: EnhancedIpfsEntry = {
+                //         name: item.linkName,
+                //         path: item.path,
+                //         cid: item.cid,
+                //         size: item.size,
+                //         type: "file",
+                //         gateway,
+                //     };
+                //     item.parent.children!.push(fileEntry);
+                //     continue;
+                // }
 
                 const dagNode: any = await fetchDagNode(item.cid);
-                if (isUnixFsDirectory(dagNode)) {
-                    const dirEntry: EnhancedIpfsEntry = {
+                if (magicIsUnixFsDir(dagNode)) {
+                    const dirEntry: IpfsEntryWithGateway = {
                         name: item.linkName,
                         path: item.path,
                         cid: item.cid,
@@ -443,7 +443,7 @@ async function resolveIpfsTree(
                     item.parent.children!.push(dirEntry);
                     enqueueChildren(dirEntry, dagNode, item.path, item.depth);
                 } else {
-                    const fileEntry: EnhancedIpfsEntry = {
+                    const fileEntry: IpfsEntryWithGateway = {
                         name: item.linkName,
                         path: item.path,
                         cid: item.cid,

--- a/src/api/v2/resolvers/generic.ts
+++ b/src/api/v2/resolvers/generic.ts
@@ -222,7 +222,6 @@ export const resolveGenericHandler = async (
                 tags?: string[];
                 source_code_git_repo?: string;
             };
-            logger.info({ ipfsFolder }, "Temp metadata");
 
             const cover = (manifest.coverImage as string | undefined) ?? undefined;
             ijMetadata = {

--- a/src/api/v2/resolvers/generic.ts
+++ b/src/api/v2/resolvers/generic.ts
@@ -9,9 +9,10 @@ import { buildMystPageFromManifest, type IJMetadata } from "../../../util/myst.j
 import { DpidResolverError, resolveDpid } from "./dpid.js";
 import type { HistoryQueryResult } from "../queries/history.js";
 import { isDpid, isVersionString } from "../../../util/validation.js";
-import { getIpfsFolderTreeByCid, ipfsCat, type EnhancedIpfsEntry } from "../data/getIpfsFolder.js";
+import { getIpfsFolderTreeByCid, ipfsCat, type IpfsEntryWithGateway } from "../data/getIpfsFolder.js";
 import { getManifest } from "../../../util/manifests.js";
 import { httpAgent, httpsAgent } from "../../../util/httpAgent.js";
+import { magicIsUnixFsDir } from "../../../util/ipfs.js";
 
 const MODULE_PATH = "/api/v2/resolvers/generic" as const;
 
@@ -49,8 +50,8 @@ export type SuccessResponse =
 
 export type ResolveGenericResponse = SuccessResponse | ErrorResponse;
 
-const flattenIpfsFolder = (ipfsFolder: EnhancedIpfsEntry): Array<EnhancedIpfsEntry> => {
-    return ipfsFolder.children?.flatMap((child: EnhancedIpfsEntry) => [child, ...flattenIpfsFolder(child)]) ?? [];
+const flattenIpfsFolder = (ipfsFolder: IpfsEntryWithGateway): Array<IpfsEntryWithGateway> => {
+    return ipfsFolder.children?.flatMap((child: IpfsEntryWithGateway) => [child, ...flattenIpfsFolder(child)]) ?? [];
 };
 
 /**
@@ -360,7 +361,7 @@ export const resolveGenericHandler = async (
             logger.info({ ipfsData: data }, "IPFS DATA");
 
             // Check for magical UnixFS clues
-            if (magicIsUnixDir(data)) {
+            if (magicIsUnixFsDir(data)) {
                 // It's a dir, respond with the raw IPLD node as JSON
                 return res.status(200).send(data);
             } else {
@@ -403,21 +404,6 @@ const getVersionIndex = (versionString: string): number => {
     logger.info({ versionString, index }, "parsed version string");
     return index;
 };
-
-/**
- * Fun with IPLD/UnixFS part 4512:
- * - UnixFS data follows this protobuf schema: https://github.com/ipfs/specs/blob/main/UNIXFS.md#data-format
- * - Length-delimited protobuf encoding writes each fields as [size,data]
- * - The `Type` field is an enum, which is 8 bits long by default
- * - `Directory` has the enum value `1`
- * - [0x8,0x1] in base64 => CAE
- *
- * Hence, "CAE" obviously says "I'm a directory!"
- */
-const MAGIC_UNIXFS_DIR_FLAG = "CAE";
-
-/* eslint-disable @typescript-eslint/no-explicit-any */
-const magicIsUnixDir = (mysteriousData: any) => mysteriousData.Data?.["/"]?.bytes === MAGIC_UNIXFS_DIR_FLAG;
 
 const rBucketRefHead = /^(root|data)\/?/;
 

--- a/src/api/v2/resolvers/generic.ts
+++ b/src/api/v2/resolvers/generic.ts
@@ -191,7 +191,10 @@ export const resolveGenericHandler = async (
                 depth: "full",
             });
         } catch (e) {
-            logger.error({ error: serializeError(e as Error), cid: dataBucket.cid }, "Failed to fetch IPFS folder tree");
+            logger.error(
+                { error: serializeError(e as Error), cid: dataBucket.cid },
+                "Failed to fetch IPFS folder tree",
+            );
             return res.status(500).send({
                 error: "Failed to fetch IPFS folder tree",
                 details: serializeError(e as Error),
@@ -201,7 +204,10 @@ export const resolveGenericHandler = async (
 
         let ijMetadata: IJMetadata | undefined;
         try {
-            const tempMetadata = (await ipfsCat(`${dataBucket.cid}/insight-journal-metadata.json`)) as unknown as {
+            const tempMetadata = (await ipfsCat(
+                `${dataBucket.cid}/insight-journal-metadata.json`,
+                true,
+            )) as unknown as {
                 license: string;
                 publication_id: number;
                 revisions: Array<{

--- a/src/redis.ts
+++ b/src/redis.ts
@@ -1,6 +1,7 @@
 import { createClient } from "redis";
 import type { RedisClientType } from "redis";
 import parentLogger from "./logger.js";
+import { errWithCause } from "pino-std-serializers";
 
 const logger = parentLogger.child({
     module: "redis.ts",
@@ -29,7 +30,8 @@ export interface RedisService {
     stop: () => Promise<void>;
     keyBump: (key: string, ttl: number) => Promise<void>;
     getFromCache: <T>(key: string) => Promise<T | null>;
-    setToCache: <T>(key: string, value: T, ttl: number) => Promise<void>;
+    setToCache: <T>(key: string, value: T, ttl: number) => Promise<boolean>;
+    del: (...keys: string[]) => Promise<void>;
 }
 
 export interface RedisConfig {
@@ -63,43 +65,91 @@ export function createRedisService(config: RedisConfig): RedisService {
 
     async function keyBump(key: string, ttl: number): Promise<void> {
         if (!client?.isReady) {
-            logger.error({ fn: "keyBump", key, op: "bump" }, "client not connected");
+            logger.warn({ fn: "keyBump", key, op: "bump" }, "client not connected");
             return;
         }
         logger.info({ fn: "keyBump", key, op: "bump" }, "refreshing cache ttl");
-        await client.expire(key, ttl);
+        try {
+            await client.expire(key, ttl);
+        } catch (e) {
+            logger.warn({ fn: "keyBump", key, op: "bump", error: errWithCause(e as Error) }, "failed to bump key");
+        }
     }
 
     async function getFromCache<T>(key: string): Promise<T | null> {
         if (!client?.isReady) {
-            logger.error({ fn: "getFromCache", key, op: "get" }, "client not connected");
+            logger.warn({ fn: "getFromCache", key, op: "get" }, "client not connected");
             return null;
         }
 
-        const result = await client.get(key);
-        if (result === null) {
-            logger.info({ fn: "getFromCache", key, op: "get" }, "key not found");
+        let result;
+        try {
+            result = await client.get(key);
+            if (result === null) {
+                logger.info({ fn: "getFromCache", key, op: "get" }, "key not found");
+                return null;
+            }
+        } catch (e) {
+            logger.warn({ fn: "getFromCache", key, op: "get" }, "Failed to get key from cache");
             return null;
         }
 
         try {
             logger.info({ fn: "getFromCache", key, op: "get" }, "key retrieved from cache");
             return JSON.parse(result);
-        } catch (error) {
-            logger.error({ fn: "getFromCache", key, op: "parse", error }, "failed to parse cached value, purging key");
-            await client.del(key);
+        } catch (e) {
+            logger.error(
+                { fn: "getFromCache", key, op: "parse", error: errWithCause(e as Error) },
+                "failed to parse cached value, purging key",
+            );
+            await client.del(key).catch((e) => {
+                logger.warn(
+                    { fn: "getFromCache", key, op: "del", error: errWithCause(e as Error) },
+                    "failed to del key",
+                );
+            });
             return null;
         }
     }
 
-    async function setToCache<T>(key: string, value: T, ttl: number): Promise<void> {
+    async function setToCache<T>(key: string, value: T, ttl: number): Promise<boolean> {
         if (!client?.isReady) {
-            logger.error({ fn: "setToCache", key, op: "set" }, "client not connected");
+            logger.warn({ fn: "setToCache", key, op: "set" }, "client not connected");
+            return false;
+        }
+
+        try {
+            await client.set(key, JSON.stringify(value), { EX: ttl });
+            logger.info({ fn: "setToCache", key, op: "set" }, "added value to cache");
+            return true;
+        } catch (e) {
+            logger.warn(
+                { fn: "setToCache", key, op: "set", error: errWithCause(e as Error) },
+                "Failed to set key to cache",
+            );
+            return false;
+        }
+    }
+
+    async function del(...keys: string[]): Promise<void> {
+        if (!client?.isReady) {
+            logger.warn({ fn: "del", keys, op: "del" }, "client not connected");
             return;
         }
 
-        await client.set(key, JSON.stringify(value), { EX: ttl });
-        logger.info({ fn: "setToCache", key, op: "set" }, "added value to cache");
+        if (keys.length === 0) {
+            return;
+        }
+
+        try {
+            await client.del(keys);
+            logger.info({ fn: "del", keys, op: "del" }, "deleted key from cache");
+        } catch (e) {
+            logger.warn(
+                { fn: "del", keys, op: "del", error: errWithCause(e as Error) },
+                "failed to del key from cache",
+            );
+        }
     }
 
     return {
@@ -142,6 +192,7 @@ export function createRedisService(config: RedisConfig): RedisService {
         keyBump,
         getFromCache,
         setToCache,
+        del,
     };
 }
 

--- a/src/util/httpAgent.ts
+++ b/src/util/httpAgent.ts
@@ -41,7 +41,7 @@ import https from "https";
  * - Large (50+ req/min): maxSockets=200, consider load balancing
  */
 
-const maxSockets = process.env.HTTP_MAX_SOCKETS ? parseInt(process.env.HTTP_MAX_SOCKETS, 10) : 50;
+const maxSockets = process.env.HTTP_MAX_SOCKETS ? parseInt(process.env.HTTP_MAX_SOCKETS, 10) : 200;
 const maxFreeSockets = process.env.HTTP_MAX_FREE_SOCKETS ? parseInt(process.env.HTTP_MAX_FREE_SOCKETS, 10) : 10;
 const timeout = process.env.HTTP_SOCKET_TIMEOUT ? parseInt(process.env.HTTP_SOCKET_TIMEOUT, 10) : 60000;
 

--- a/src/util/ipfs.ts
+++ b/src/util/ipfs.ts
@@ -1,0 +1,84 @@
+/**
+ * This module tries to be a reference over UnixFS DagPB internals,
+ * as well as our various hacks and abuses of the same.
+ *
+ * The types are rough approximations to communicate the basics, for more
+ * details see the spec: https://specs.ipfs.tech/unixfs/#dag-pb-node
+ *
+ * Sorry to see you here, as it probably means you are debugging something
+ * particularly nasty.
+ */
+
+/**
+ * Link from DagPB Node to a child. A child is either:
+ * - A directory (DagPB node with named links)
+ * - A file node (i.e., a DagPbNode with unnamed children AND Data !== "CAE" )
+ * - A raw block (unchunked file)
+ */
+export type PbLink = {
+    /**
+     * CID string. Notably:
+     * - bafkrei... => raw codec    => target is unsharded raw file, no DagPB wrapper
+     * - bafybei... => dag-pb codec => target is dir or file node
+     */
+    Hash: {
+        "/": string;
+    };
+    /**
+     * In dir node: filename of child
+     * In file node: empty string (chunks/raw data block)
+     */
+    Name: string;
+    /**
+     * SHOULD (according to spec) be cumulative, recursive DAG size of linked object.
+     * COULD (empirically) be 0 if the link is a directory.
+     */
+    Tsize: number;
+};
+
+/**
+ * A DagPbNode comes in three flavours
+ */
+export type DagPbNode = {
+    /**
+     * DagPB Data message, encoded in base64. Important cases:
+     * - CAE  => the node is a directory, see docs on MAGIC_UNIXFS_DIR_FLAG
+     * - else => the node is a sharded file (or other exotic DagPB, but probably not)
+     */
+    Data: {
+        "/": typeof MAGIC_UNIXFS_DIR_FLAG | string;
+    };
+    Links: PbLink[];
+};
+
+/**
+ * Fun with IPLD/UnixFS part 4512:
+ * - UnixFS data follows this protobuf schema: https://github.com/ipfs/specs/blob/main/UNIXFS.md#data-format
+ * - Length-delimited protobuf encoding writes each fields as [size,data]
+ * - The `Type` field is an enum, which is 8 bits long by default
+ * - `Directory` has the enum value `1`
+ * - [0x8,0x1] in base64 => CAE
+ *
+ * Hence, "CAE" obviously says "I'm a directory!"
+ */
+export const MAGIC_UNIXFS_DIR_FLAG = "CAE";
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+export const magicIsUnixFsDir = (mysteriousData: any) => mysteriousData?.Data?.["/"]?.bytes === MAGIC_UNIXFS_DIR_FLAG;
+
+/**
+ * Check if a CID uses the raw codec (multicodec 0x55), meaning it's a leaf
+ * file whose content IS the raw bytes — never a UnixFS directory.
+ *
+ * CIDv1 base32 encodes: <multibase><version><codec><multihash...>
+ * "bafkrei" = base32lower 'b' + CIDv1 version 0x01 + raw codec 0x55 + sha2-256 0x1220.
+ * Any CID starting with this prefix is guaranteed to be a raw file leaf.
+ */
+export const isRawCodecCid = (cid: string): boolean => cid.startsWith("bafkrei");
+
+/**
+ * Returns true if the Tsize of a link is 0, which might indicate it's a directory
+ * with incorrect size set. Can be used to filter out files, but a true should probably
+ * be followed up with a magicIsUnixFsDir call to make sure.
+ */
+export const hackyTsizeIsDir = (link: PbLink) => link.Tsize === 0;

--- a/src/util/myst.ts
+++ b/src/util/myst.ts
@@ -1,11 +1,11 @@
 import type { ResearchObjectV1, ResearchObjectV1Author } from "@desci-labs/desci-models";
 import type { HistoryQueryResult } from "../api/v2/queries/history.js";
-import type { EnhancedIpfsEntry } from "../api/v2/data/getIpfsFolder.js";
+import type { IpfsEntryWithGateway } from "../api/v2/data/getIpfsFolder.js";
 
 export type IJMetadata = {
     affiliations?: Record<string, string>;
     corresponding_author?: string;
-    flatFiles?: Array<EnhancedIpfsEntry> | undefined;
+    flatFiles?: Array<IpfsEntryWithGateway> | undefined;
     license_text?: string;
     id?: number;
     journal_name?: string;
@@ -197,7 +197,7 @@ export async function buildMystPageFromManifest(params: {
             thumbnail_optimized: thumbnailOptimized,
         },
         mdast: { type: "root" },
-        downloads: ij.flatFiles?.map((f: EnhancedIpfsEntry) => {
+        downloads: ij.flatFiles?.map((f: IpfsEntryWithGateway) => {
             // Use the gateway that successfully fetched the file
             let gatewayUrl: string;
             if (!f.gateway || f.gateway === "public") {

--- a/test/v2/data.spec.ts
+++ b/test/v2/data.spec.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { createRequire } from "module";
+import { app } from "../../src/index.js";
+import type { TestResponse } from "../testUtils.js";
+
+const require = createRequire(import.meta.url);
+const request = require("supertest");
+
+describe("/api/v2/data", { timeout: 60_000 }, () => {
+    describe("GET /api/v2/data/cid/:cid", () => {
+        it("should assign correct gateway to files", async () => {
+            await request(app)
+                .get("/api/v2/data/cid/bafybeihcxoylynlvflnziuw457yfquev7zb4kgmskcxv3vj6u4hfs3dfrq?depth=full")
+                .expect(200)
+                .expect((res: TestResponse) => {
+                    expect(res.body).toMatchObject({
+                        children: expect.arrayContaining([
+                            expect.objectContaining({
+                                path: "bafybeihcxoylynlvflnziuw457yfquev7zb4kgmskcxv3vj6u4hfs3dfrq/insight-journal-metadata.json",
+                                size: 9095,
+                                type: "file",
+                                gateway: "https://ipfs.desci.com/api/v0",
+                            }),
+                            expect.objectContaining({
+                                name: "manuscript.pdf",
+                                path: "bafybeihcxoylynlvflnziuw457yfquev7zb4kgmskcxv3vj6u4hfs3dfrq/manuscript.pdf",
+                                gateway: "https://pub.desci.com/api/v0",
+                            }),
+                            expect.objectContaining({
+                                name: "code",
+                                path: "bafybeihcxoylynlvflnziuw457yfquev7zb4kgmskcxv3vj6u4hfs3dfrq/code",
+                                gateway: "https://ipfs.desci.com/api/v0",
+                                children: expect.arrayContaining([
+                                    expect.objectContaining({
+                                        name: "itk-module.cmake",
+                                        path: "bafybeihcxoylynlvflnziuw457yfquev7zb4kgmskcxv3vj6u4hfs3dfrq/code/itk-module.cmake",
+                                        gateway: "https://pub.desci.com/api/v0",
+                                    }),
+                                ]),
+                            }),
+                        ]),
+                    });
+                });
+        });
+    });
+});


### PR DESCRIPTION
The main perf and reliability boost comes from the fact that the unixFS dag-pb nodes of all IJ external CIDs have the `Tsize` (incorrectly) set to 0 on every directory node, and consequently each file (both chunked and raw) has a non-zero `Tsize`. This is (ab)used in `hackyTsizeIsDir(link: PbLink)` to skip fetching blocks for _any file at all_ when walking the DAG, and hence _dramatically_ reduces the amount of IPFS I/O needed to discover the file tree.

The obvious caveat is that this might not be true for other nodes, but it seems to work for all IJ publications without exceptions. A full IJ article+assets prefetch round now completes in under 13 mins **without redis**, without any errors. Obv faster and less churn with redis, but now clean runs are also successful.

Messy history, but some other key improvements:
- Higher `maxSockets` for http agents to reduce IPFS request queue-up under higher concurrency
  - Resulting load increase on kubo node not really noticeable
- Add toggle param to `ipfsCat` for caching results (mainly used for reading IJ metadata files for MyST)
- Subtree caching and DFS changes were reverted, caching overhead was too wild

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced IPFS folder resolution with improved caching for faster data retrieval
  * Intelligent gateway selection mechanism for more reliable connections
  * Increased support for concurrent connections (default pool size expanded)

* **Bug Fixes**
  * Improved error handling and logging for better diagnostic clarity
  * Enhanced Redis caching with graceful failure handling

* **Tests**
  * Added integration test for IPFS data endpoint

<!-- end of auto-generated comment: release notes by coderabbit.ai -->