### PR TITLE
fix: missing bytes wrapper in dag-pb type

### DIFF
--- a/src/util/ipfs.ts
+++ b/src/util/ipfs.ts
@@ -46,7 +46,9 @@ export type DagPbNode = {
      * - else => the node is a sharded file (or other exotic DagPB, but probably not)
      */
     Data: {
-        "/": typeof MAGIC_UNIXFS_DIR_FLAG | string;
+        "/": {
+            bytes: typeof MAGIC_UNIXFS_DIR_FLAG | string;
+        };
     };
     Links: PbLink[];
 };


### PR DESCRIPTION
silly little :bug: 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated IPFS node data type structure to align with the underlying data representation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->