### PR TITLE
fix: prevent crash from circular AxiosError serialization

### DIFF
--- a/src/api/v2/resolvers/generic.ts
+++ b/src/api/v2/resolvers/generic.ts
@@ -191,7 +191,10 @@ export const resolveGenericHandler = async (
                 depth: "full",
             });
         } catch (e) {
-            logger.error({ error: serializeError(e as Error), cid: dataBucket.cid }, "Failed to fetch IPFS folder tree");
+            logger.error(
+                { error: serializeError(e as Error), cid: dataBucket.cid },
+                "Failed to fetch IPFS folder tree",
+            );
             return res.status(500).send({
                 error: "Failed to fetch IPFS folder tree",
                 details: serializeError(e as Error),
@@ -365,9 +368,19 @@ export const resolveGenericHandler = async (
             }
         } catch (e) {
             // Doesn't seem it was a validDagUrl
+            // AxiosError contains circular references (request.res.req) that crash
+            // JSON.stringify, so we extract only safe, serializable fields
+            const axiosErr = e as import("axios").AxiosError;
+            const safeDetails = {
+                message: axiosErr.message,
+                code: axiosErr.code,
+                status: axiosErr.response?.status,
+                statusText: axiosErr.response?.statusText,
+                url: axiosErr.config?.url,
+            };
             const errPayload = {
                 error: "Failed to resolve DAG URL; check path and versioning",
-                details: serializeError(e as Error),
+                details: safeDetails,
                 ...baseError,
             };
             logger.error(errPayload, "got invalid DAG URL");


### PR DESCRIPTION
## Summary
- When IPFS DAG requests fail, the catch block passed the raw AxiosError to `res.send()`
- AxiosError has circular references (`request.res.req`) causing `JSON.stringify` to throw
- This became an unhandled rejection → `process.exit(1)` → 82 restarts in 14 hours
- Fix: extract only safe fields (message, code, status, url) from the error

## Root cause
`serializeError` (pino's `stdSerializers.err()`) doesn't strip Axios's circular internal references. When Express called `JSON.stringify` on the response, it crashed the process.

## Test plan
- [x] Deployed to prod — 0 restarts after triggering error path
- [x] `GET /1065/root/nonexistent/path?format=raw` returns 404 JSON without crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved error logging formatting for IPFS folder tree operations.
  * Enhanced error details collection during DAG URL resolution failures, now capturing additional diagnostic information including HTTP status codes and request configuration for better troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->